### PR TITLE
Skip lazy link when references are blank

### DIFF
--- a/lib/topological_inventory/providers/common/collector/parser.rb
+++ b/lib/topological_inventory/providers/common/collector/parser.rb
@@ -16,6 +16,11 @@ module TopologicalInventory
           end
 
           def lazy_find(collection, reference, ref: :manager_ref)
+            return if reference.kind_of?(String) && reference.blank?
+
+            # Don't make lazy link if all reference values are blank
+            return if reference.kind_of?(Hash) && reference.values.select { |val| val.to_s.present? }.blank?
+
             TopologicalInventoryIngressApiClient::InventoryObjectLazy.new(
               :inventory_collection_name => collection,
               :reference                 => reference,


### PR DESCRIPTION
When lazy_find's reference ==  `:source_ref => ''`, then it is obviously null reference (found in ansible tower)
It means that it shouldn't create lazy link but keep foreign key equal NULL