### PR TITLE
Bump topological-api-client to 3.0.1

### DIFF
--- a/lib/topological_inventory/providers/common/version.rb
+++ b/lib/topological_inventory/providers/common/version.rb
@@ -1,7 +1,7 @@
 module TopologicalInventory
   module Providers
     module Common
-      VERSION = "0.1.1"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/topological_inventory-providers-common.gemspec
+++ b/topological_inventory-providers-common.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Common classes for topological-inventory collectors/operations}
   spec.description   = %q{Common classes for topological-inventory collectors/operations}
-  spec.homepage      = "https://github.com/slemrmartin/topological_inventory-providers-common"
+  spec.homepage      = "https://github.com/RedHatInsights/topological_inventory-providers-common"
   spec.license       = "Apache-2.0"
 
   # Specify which files should be added to the gem when it is released.
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", "~> 5.2.2"
   spec.add_runtime_dependency "manageiq-loggers", "~> 0.4.0", ">= 0.4.2"
   spec.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
-  spec.add_runtime_dependency "topological_inventory-api-client", "~> 2.0"
+  spec.add_runtime_dependency "topological_inventory-api-client", "~> 3.0", ">= 3.0.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-ansible_tower/issues/83

---

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-api-client-ruby/pull/31 **[requires RubyGems release]**

**dependents**:
- https://github.com/RedHatInsights/topological_inventory-ansible_tower/pull/84
- https://github.com/RedHatInsights/topological_inventory-amazon/pull/62
- https://github.com/RedHatInsights/topological_inventory-azure/pull/24
- https://github.com/RedHatInsights/topological_inventory-openshift/pull/121
- https://github.com/RedHatInsights/topological_inventory-satellite/pull/21

---

**Gem version: 1.0.0**
- [x] released to **RubyGems**

