### PR TITLE
Add support for heartbeat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ gem "topological_inventory-ingress_api-client", "~> 1.0"
 group :development, :test do
   gem 'rake', '~> 12.0.0'
   gem 'pry-byebug'
+  gem 'timecop'
 end

--- a/lib/topological_inventory/providers/common/collector.rb
+++ b/lib/topological_inventory/providers/common/collector.rb
@@ -12,7 +12,7 @@ module TopologicalInventory
       class Collector
         # @param poll_time [Integer] Waiting between collecting loops. Irrelevant for standalone_mode: true
         # @param standalone_mode [Boolean] T/F if collector is created by collectors_pool
-        def initialize(source, default_limit: 1_000, poll_time: 30, standalone_mode: true)
+        def initialize(source, default_limit: 1_000, poll_time: 30, standalone_mode: true, heartbeat_queue: nil)
           self.collector_threads = Concurrent::Map.new
           self.finished          = Concurrent::AtomicBoolean.new(false)
           self.poll_time         = poll_time
@@ -20,6 +20,7 @@ module TopologicalInventory
           self.queue             = Queue.new
           self.source            = source
           self.standalone_mode   = standalone_mode
+          self.heartbeat_queue   = heartbeat_queue
         end
 
         def collect!
@@ -44,7 +45,8 @@ module TopologicalInventory
         protected
 
         attr_accessor :collector_threads, :finished, :limits,
-                      :poll_time, :queue, :source, :standalone_mode
+                      :poll_time, :queue, :source, :standalone_mode,
+                      :heartbeat_queue
 
         def finished?
           finished.value

--- a/lib/topological_inventory/providers/common/heartbeat.rb
+++ b/lib/topological_inventory/providers/common/heartbeat.rb
@@ -1,0 +1,168 @@
+module TopologicalInventory
+  module Providers
+    module Common
+      class << self
+        attr_writer :heartbeat
+      end
+
+      def self.heartbeat(name, max_thread_timeout)
+        @heartbeat ||= {}
+        @heartbeat[name] ||= TopologicalInventory::Providers::Common::Heartbeat.new(name, max_thread_timeout)
+      end
+
+      module HeartbeatQueue
+        def heartbeat(name, max_thread_timeout = 65)
+          TopologicalInventory::Providers::Common.heartbeat(name, max_thread_timeout)
+        end
+      end
+
+      class Heartbeat
+        HEARTBEAT_CHECK_TIMEOUT             = 12.freeze
+        HEARTBEAT_TIMEOUT                   = 10.freeze
+        HEARTBEAT_QUEUE_THREAD_TIMEOUT_STEP = 10.freeze
+        HEARTBEAT_THREAD_TIMEOUT_STEP       = 10.freeze
+
+        attr_accessor :finished, :heartbeat_queue, :name, :max_thread_timeout, :queue_thread_finished
+
+        def initialize(name, max_thread_timeout = 65)
+          self.heartbeat_queue = Concurrent::Array.new([:tick])
+          self.finished = Concurrent::AtomicBoolean.new(false)
+          self.queue_thread_finished = Concurrent::AtomicBoolean.new(false)
+          self.name = name
+          self.max_thread_timeout = max_thread_timeout
+
+          self.create_heartbeat_dir
+          self.touch_heartbeat_file
+        end
+
+        def run_thread
+          Thread.new do
+            until finished.value
+              if self.heartbeat_queue.present?
+                self.touch_heartbeat_file
+                self.heartbeat_queue.clear
+              end
+
+              sleep(HEARTBEAT_TIMEOUT)
+            end
+          end
+        end
+
+        def run_queue_thread_with_timeout
+          self.queue_thread_finished = Concurrent::AtomicBoolean.new(false)
+          Thread.new do
+            current_time_thread = 0
+
+            until queue_thread_finished.value
+              sleep(HEARTBEAT_QUEUE_THREAD_TIMEOUT_STEP)
+
+              current_time_thread += HEARTBEAT_QUEUE_THREAD_TIMEOUT_STEP
+              if current_time_thread > self.max_thread_timeout
+                stop_queue_thread
+              else
+                self.queue_tick
+              end
+            end
+          end
+        end
+
+        def run_thread_queue_in_parallel_with
+          run_queue_thread_with_timeout
+
+          yield
+        ensure
+          stop_queue_thread
+        end
+
+        def run_thread_with_timeout
+          self.finished = Concurrent::AtomicBoolean.new(false)
+
+          Thread.new do
+            current_time_thread = 0
+            until finished.value
+              sleep(HEARTBEAT_THREAD_TIMEOUT_STEP)
+
+              current_time_thread += HEARTBEAT_THREAD_TIMEOUT_STEP
+              if current_time_thread > self.max_thread_timeout
+                stop
+              else
+                self.touch_heartbeat_file
+              end
+            end
+          end
+        end
+
+        def run_in_parallel_with
+          run_thread_with_timeout
+
+          yield
+        ensure
+          stop
+        end
+
+        def queue_tick
+          self.heartbeat_queue << :tick
+        end
+
+        def stop
+          self.finished = Concurrent::AtomicBoolean.new(true)
+        end
+
+        def stop_queue_thread
+          self.queue_thread_finished = Concurrent::AtomicBoolean.new(true)
+        end
+
+        def touch_heartbeat_file
+          File.write(self.heartbeat_file, (Time.now.utc + HEARTBEAT_CHECK_TIMEOUT).to_s)
+        end
+
+        def create_heartbeat_dir
+          Dir.mkdir(heartbeat_dir) unless File.exist?(heartbeat_dir)
+        end
+
+        def heartbeat_dir
+          self.class.heartbeat_dir
+        end
+
+        def heartbeat_file
+          self.class.heartbeat_file(self.name)
+        end
+
+        def self.heartbeat_dir
+          require 'tmpdir'
+          File.join(Dir.tmpdir, 'heartbeat_files')
+        end
+
+        def self.heartbeat_file_path(name)
+          "#{heartbeat_dir}/heartbeat_file-#{name}.hb"
+        end
+
+        def self.heartbeat_file(name)
+          File.expand_path(self.heartbeat_file_path(name), __FILE__)
+        end
+
+        def self.check(name)
+          require 'time'
+
+          hb_file = heartbeat_file(name)
+
+          if File.exist?(hb_file)
+            current_time = Time.now.utc
+            contents     = File.read(hb_file)
+            mtime        = File.mtime(hb_file).utc
+
+            timeout      = if contents.empty?
+                             (mtime + HEARTBEAT_CHECK_TIMEOUT).utc
+                           else
+                             Time.parse(contents).utc
+                           end
+
+            current_time <= timeout
+          else
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "topological_inventory/providers/common"
+require "timecop"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/topological_inventory/providers/common/heartbeat_spec.rb
+++ b/spec/topological_inventory/providers/common/heartbeat_spec.rb
@@ -1,0 +1,141 @@
+RSpec.describe TopologicalInventory::Providers::Common::Heartbeat do
+  let(:heartbeat_file) { Pathname.new(File.expand_path("../../", __FILE__).to_s).join("tmp", "spec", "test.hb") }
+
+  around do |spec|
+    FileUtils.mkdir_p(heartbeat_file.parent)
+
+    Timecop.travel(time) do
+      File.write(heartbeat_file, "")
+    end
+
+    Timecop.freeze(time) { spec.run }
+
+    FileUtils.rm_f(heartbeat_file.to_s)
+  end
+
+  let(:time) { Time.now.utc }
+
+  before do
+    stub_const("TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_TIMEOUT", 2)
+    stub_const("TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_CHECK_TIMEOUT", 2)
+
+    allow(described_class).to receive(:heartbeat_file_path).with("operations").and_return(heartbeat_file)
+  end
+
+  it "fails when heartbeat file is not created" do
+    FileUtils.rm_f(heartbeat_file.to_s)
+
+    Timecop.travel(time) do
+      expect(described_class.check('operations')).to be_falsey
+    end
+
+    Timecop.travel(time) do
+      File.write(heartbeat_file, "")
+    end
+  end
+
+  it "performs heartbeat by calling method touch_heartbeat_file" do
+    heartbeat = described_class.new('operations')
+
+    Timecop.travel(time + 1) do
+      expect(described_class.check('operations')).to be_truthy
+    end
+
+    Timecop.travel(time + 3) do
+      expect(described_class.check('operations')).to be_falsey
+    end
+
+    Timecop.travel(time + 4) do
+      heartbeat.touch_heartbeat_file
+    end
+
+    Timecop.travel(time + 5) do
+      expect(described_class.check('operations')).to be_truthy
+    end
+
+    Timecop.travel(time + 6) do
+      expect(described_class.check('operations')).to be_falsey
+    end
+  end
+
+  it "performs heartbeat from thread" do
+    stub_const("TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_THREAD_TIMEOUT_STEP", 1)
+
+    heartbeat = described_class.new('operations')
+    heartbeat.heartbeat_queue.clear
+
+    heartbeat.run_thread
+    heartbeat.queue_tick
+
+    sleep(TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_THREAD_TIMEOUT_STEP + 1)
+    expect(heartbeat.heartbeat_queue.count).to eq(0)
+
+    Timecop.travel(time + 1) do # heartbeat didn't expired
+      expect(described_class.check('operations')).to be_truthy
+    end
+
+    Timecop.travel(time + 3) do # heartbeat expired
+      expect(described_class.check('operations')).to be_falsey
+    end
+
+    stub_const("TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_THREAD_TIMEOUT_STEP", 0)
+    heartbeat.stop
+  end
+
+  describe '#run_in_parallel_with' do
+    it "performs heartbeat from touch_heartbeat_file with exceeding max limit" do
+      stub_const("TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_QUEUE_THREAD_TIMEOUT_STEP", 1)
+      stub_const("TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_TIMEOUT", 1)
+
+      heartbeat = described_class.new('operations')
+      heartbeat.heartbeat_queue.clear
+
+      heartbeat.max_thread_timeout = 2
+
+      Timecop.travel(time) do
+        heartbeat.run_in_parallel_with do
+          sleep(4)
+        end
+      end
+
+      Timecop.travel(time + 1) do # heartbeat not expired
+        expect(described_class.check('operations')).to be_truthy
+      end
+
+      Timecop.travel(time + 3) do # heartbeat expired as max_thread_timeout was exceed
+        expect(described_class.check('operations')).to be_falsey
+      end
+
+      heartbeat.stop
+    end
+  end
+
+  describe '#run_thread_queue_in_parallel_with' do
+    it "performs heartbeat from thread with exceeding max limit" do
+      stub_const("TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_QUEUE_THREAD_TIMEOUT_STEP", 1)
+      stub_const("TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_TIMEOUT", 1)
+      stub_const("TopologicalInventory::Providers::Common::Heartbeat::HEARTBEAT_CHECK_TIMEOUT", 2)
+
+      heartbeat = described_class.new('operations')
+      heartbeat.heartbeat_queue.clear
+      heartbeat.run_thread
+      heartbeat.max_thread_timeout = 2
+
+      Timecop.travel(time) do
+        heartbeat.run_thread_queue_in_parallel_with do
+          sleep(4) # 4 seconds are exceeding HEARTBEAT_TIMEOUT(1 second) + HEARTBEAT_CHECK_TIMEOUT(2 seconds)
+        end
+      end
+
+      Timecop.travel(time + 1) do # heartbeat not expired
+        expect(described_class.check('operations')).to be_truthy
+      end
+
+      Timecop.travel(time + 4) do # heartbeat expired as max_thread_timeout was exceed
+        expect(described_class.check('operations')).to be_falsey
+      end
+
+      heartbeat.stop
+    end
+  end
+end


### PR DESCRIPTION
this adds heartbeat support for collector and operations worker:

Usages:
```ruby

1) 
hb = TopologicalInventory::Providers::Common::Heartbeat.new('operations')
TopologicalInventory::Providers::Common::Heartbeat.check('operations')
# => false # never touch heartbeat file

2)  Touch file checking
hb = TopologicalInventory::Providers::Common::Heartbeat.new('operations')
hb.touch_heartbeat_file # t1 =  now
TopologicalInventory::Providers::Common::Heartbeat.check('operations')
# => true at time=<t1, HEARTBEAT_CHECK_TIMEOUT>, otherwise false
#default HEARTBEAT_CHECK_TIMEOUT = 12 

3) Queue checking
hb = TopologicalInventory::Providers::Common::Heartbeat.new('operations')
# starts to check if self.heartbeat_queue empty each HEARTBEAT_TIMEOUT seconds. 
# when self.heartbeat_queue is not empty it performs hb.touch_heartbeat_file
# self.heartbeat_queue is shared queue
hb.queue_tick # init at t1 = now, put to `self.heartbeat_queue`
hb.run_thread 
TopologicalInventory::Providers::Common::Heartbeat.check('operations')
# => true, in time <t1, HEARTBEAT_TIMEOUT>, otherwise false

hb.queue_tick # t2 = t1 + HEARTBEAT_TIMEOUT + 2
TopologicalInventory::Providers::Common::Heartbeat.check('operations')
# => false exactly in time t2, otherwise false and
# we have to wait <t2, HEARTBEAT_TIMEOUT> time to calling method `touch_heartbeat_file` by run_thread.

3) run_in_parallel_with 
hb = TopologicalInventory::Providers::Common::Heartbeat.new('operations')
hb.run_thread 
# this block create new thread which is doing by touching heartbeat file each `HEARTBEAT_THREAD_TIMEOUT_STEP` (10 seconds) but when time exceeds hb.max_thread_timeout it will stop touching heartbeat file and method check will return false

hb.run_in_parallel_with do
   # this operation can take max hb.max_thread_timeout seconds
end

4) run_thread_queue_in_parallel_with
hb = TopologicalInventory::Providers::Common::Heartbeat.new('operations')
# same as 3) but checking mechanism is Queue checking - so it uses queue for
# heartbeat ticks and queue is check in thread from run_thread where method touch_heartbeat_file is called- it is ensured that just one thread can access heartbeat file.

hb.run_thread_queue_in_parallel_with do
   # this operation can take max hb.max_thread_timeout seconds
end



```
@miq-bot assign @slemrmartin 


Used in 
- [ ]  https://github.com/RedHatInsights/topological_inventory-ansible_tower/pull/88
