### PR TITLE
Specifying minimal version of manageiq-loggers

### DIFF
--- a/topological_inventory-providers-common.gemspec
+++ b/topological_inventory-providers-common.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'config', '~> 1.7', '>= 1.7.2'
   spec.add_runtime_dependency "activesupport", "~> 5.2.2"
-  spec.add_runtime_dependency "manageiq-loggers", "~> 0.5.0"
+  spec.add_runtime_dependency "manageiq-loggers", ">= 0.4.2"
   spec.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
   spec.add_runtime_dependency "topological_inventory-api-client", "~> 3.0", ">= 3.0.1"
 


### PR DESCRIPTION
Following #19. I believe it will be better to specify minimal version in gemspec and increase version in dependent repos where needed