### PR TITLE
Extend logger with common logging phrases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2020-05-15
+### Changed
+
+Extend logger with common logging phrases #22
+
 ## [1.0.1] - 2020-05-06
 ### Changed
 
@@ -15,5 +20,6 @@ manageiq-loggers to >= 0.4.2 #20
 ### Initial release to rubygems.org
 
 [Unreleased]: https://github.com/RedHatInsights/topological_inventory-providers-common/compare/v1.0.1...HEAD
+[1.0.2]: https://github.com/RedHatInsights/topological_inventory-providers-common/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/RedHatInsights/topological_inventory-providers-common/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/RedHatInsights/topological_inventory-providers-common/releases/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 Extend logger with common logging phrases #22
+Security update: JSON 2.3, ActiveSupport 5.2.4.3 #23
 
 ## [1.0.1] - 2020-05-06
 ### Changed

--- a/lib/topological_inventory/providers/common/logging.rb
+++ b/lib/topological_inventory/providers/common/logging.rb
@@ -3,13 +3,38 @@ require "manageiq/loggers"
 module TopologicalInventory
   module Providers
     module Common
+      module LoggingFunctions
+        def collecting(status, source, entity_type, refresh_state_uuid, total_parts = nil)
+          msg = "[#{status.to_s.upcase}] Collecting #{entity_type}"
+          msg += ", :total parts => #{total_parts}" if total_parts.present?
+          msg += ", :source_uid => #{source}, :refresh_state_uuid => #{refresh_state_uuid}"
+          info(msg)
+        end
+
+        def collecting_error(source, entity_type, refresh_state_uuid, exception)
+          msg = "[ERROR] Collecting #{entity_type}, :source_uid => #{source}, :refresh_state_uuid => #{refresh_state_uuid}"
+          msg += ":message => #{exception.message}\n#{exception.backtrace.join("\n")}"
+          error(msg)
+        end
+
+        def sweeping(status, source, sweep_scope, refresh_state_uuid)
+          msg = "[#{status.to_s.upcase}] Sweeping inactive records, :sweep_scope => #{sweep_scope}, :source_uid => #{source}, :refresh_state_uuid => #{refresh_state_uuid}"
+          info(msg)
+        end
+      end
+
+      class Logger < ManageIQ::Loggers::CloudWatch
+        def self.new(*args)
+          super.tap { |logger| logger.extend(TopologicalInventory::Providers::Common::LoggingFunctions) }
+        end
+      end
+
       class << self
         attr_writer :logger
       end
 
       def self.logger
-        @logger ||= ManageIQ::Loggers::Container.new
-        @logger
+        @logger ||= TopologicalInventory::Providers::Common::Logger.new
       end
 
       module Logging

--- a/lib/topological_inventory/providers/common/version.rb
+++ b/lib/topological_inventory/providers/common/version.rb
@@ -1,7 +1,7 @@
 module TopologicalInventory
   module Providers
     module Common
-      VERSION = "1.0.1"
+      VERSION = "1.0.2"
     end
   end
 end

--- a/spec/topological_inventory/providers/common/logger_spec.rb
+++ b/spec/topological_inventory/providers/common/logger_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe TopologicalInventory::Providers::Common::Logger do
+  let(:status) { :test }
+  let(:source) { '92844e11-17d5-4998-a33d-d886c3c7a80e' }
+  let(:entity_type) { 'test-entity' }
+  let(:refresh_state_uuid) { 'cd22ba1c-56f6-4fd4-a191-ec8eb8e993a8' }
+  let(:sweep_scope) { [entity_type] }
+  let(:total_parts) { 10 }
+
+  subject { described_class.new }
+
+  it 'receives collecting method' do
+    msg = "[#{status.to_s.upcase}] Collecting #{entity_type}"
+    msg += ", :total parts => #{total_parts}" if total_parts.present?
+    msg += ", :source_uid => #{source}, :refresh_state_uuid => #{refresh_state_uuid}"
+    expect(subject).to receive(:info).with(msg)
+
+    subject.collecting(status, source, entity_type, refresh_state_uuid, total_parts)
+  end
+
+  it 'receives sweeping method' do
+    msg = "[#{status.to_s.upcase}] Sweeping inactive records, :sweep_scope => #{sweep_scope}, :source_uid => #{source}, :refresh_state_uuid => #{refresh_state_uuid}"
+    expect(subject).to receive(:info).with(msg)
+
+    subject.sweeping(status, source, sweep_scope, refresh_state_uuid)
+  end
+
+  it 'receives collecting error method' do
+    begin
+      raise 'Test exception'
+    rescue => e
+      msg = "[ERROR] Collecting #{entity_type}, :source_uid => #{source}, :refresh_state_uuid => #{refresh_state_uuid}"
+      msg += ":message => #{e.message}\n#{e.backtrace.join("\n")}"
+      expect(subject).to receive(:error).with(msg)
+
+      subject.collecting_error(source, entity_type, refresh_state_uuid, e)
+    end
+  end
+end


### PR DESCRIPTION
Adding logging phrases common to all collectors to unify logging output

- `logger.collecting`
- `logger.sweeping`
- `logger.collecting_error`

---

**Used by**:

- https://github.com/RedHatInsights/topological_inventory-ansible_tower/pull/91
- https://github.com/RedHatInsights/topological_inventory-amazon/pull/63
- https://github.com/RedHatInsights/topological_inventory-azure/pull/26
- https://github.com/RedHatInsights/topological_inventory-openshift/pull/122

---

**Gem version: 1.0.2**
- [ ] Released to **RubyGems**

---

**TPINVTRY-938**