### PR TITLE
Changelog 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.3] - 2020-06-?
+## [1.0.4] - 2020-06-09
+Common availability check operation #25
+Rubocop and codecoverage #29
+
+## [1.0.3] - 2020-06-04
 ### Changed
 
 Bump Sources API client to 3.0 #26
@@ -25,7 +29,8 @@ manageiq-loggers to >= 0.4.2 #20
 ## [1.0.0] - 2020-03-19
 ### Initial release to rubygems.org
 
-[Unreleased]: https://github.com/RedHatInsights/topological_inventory-providers-common/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/RedHatInsights/topological_inventory-providers-common/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/RedHatInsights/topological_inventory-providers-common/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/RedHatInsights/topological_inventory-providers-common/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/RedHatInsights/topological_inventory-providers-common/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/RedHatInsights/topological_inventory-providers-common/compare/v1.0.0...v1.0.1

--- a/lib/topological_inventory/providers/common/version.rb
+++ b/lib/topological_inventory/providers/common/version.rb
@@ -1,7 +1,7 @@
 module TopologicalInventory
   module Providers
     module Common
-      VERSION = "1.0.3"
+      VERSION = "1.0.4"
     end
   end
 end


### PR DESCRIPTION
**Gem version: 1.0.4**
- [x] Released to RubyGems

---

**Depends on**
- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/25
- [x] #29 
- [x] #31 