### PR TITLE
Add clamp to max_bytes size based on ENV var

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ end
 require "bundler/setup"
 require "topological_inventory/providers/common"
 
+spec_path = File.dirname(__FILE__)
+Dir[File.join(spec_path, "support/**/*.rb")].each { |f| require f }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/support/inventory_helper.rb
+++ b/spec/support/inventory_helper.rb
@@ -1,0 +1,14 @@
+module InventorySpecHelper
+  def self.big_inventory(size, chunk_size)
+    {
+      :collections => [
+        :name => SecureRandom.uuid,
+        :data => data_chunks(size, chunk_size)
+      ]
+    }
+  end
+
+  def self.data_chunks(size, chunk)
+    Array.new(size / chunk) { "a" * chunk }
+  end
+end

--- a/spec/topological_inventory/providers/common/save_inventory/saver_spec.rb
+++ b/spec/topological_inventory/providers/common/save_inventory/saver_spec.rb
@@ -1,0 +1,65 @@
+require "topological_inventory/providers/common/save_inventory/saver"
+
+RSpec.describe TopologicalInventory::Providers::Common::SaveInventory::Saver do
+  let(:client) { instance_double(TopologicalInventoryIngressApiClient::DefaultApi) }
+  let(:logger) { double }
+  let(:base_args) { {client: client, logger: logger} }
+
+  let(:small_json) { {:test => ["values"]} }
+  let(:big_json) { InventorySpecHelper.big_inventory(80_000, 1_000) }
+
+  describe "#save" do
+    subject { described_class.new(args).save(:inventory => inventory) }
+
+    context "when the data size is less than max_bytes" do
+      let(:args) { base_args }
+      let(:inventory) { small_json }
+
+      before do
+        allow(client).to receive(:save_inventory_with_http_info).with(small_json.to_json)
+      end
+
+      it "returns that it saved one chunk" do
+        is_expected.to eq 1
+      end
+
+      it "does not split the payload into batches" do
+        expect(client).to receive(:save_inventory_with_http_info).with(small_json.to_json).once
+        subject
+      end
+    end
+
+    context "when the data size is greater than specified max_bytes" do
+      let(:args) { base_args.merge!(:max_bytes => 19_512) }
+      let(:inventory) { big_json }
+
+      before do
+        allow(client).to receive(:save_inventory_with_http_info)
+      end
+
+      it "returns that it saved five chunks" do
+        is_expected.to eq 5
+      end
+
+      it "splits the payload up into chunks" do
+        expect(client).to receive(:save_inventory_with_http_info).exactly(5).times
+        subject
+      end
+    end
+
+    context "when the KAFKA_PAYLOAD_MAX_BYTES ENV var is set" do
+      let(:args) { base_args }
+      let(:inventory) { big_json }
+
+      before do
+        allow(ENV).to receive(:[]).with("KAFKA_PAYLOAD_MAX_BYTES").and_return("9_512")
+        allow(client).to receive(:save_inventory_with_http_info)
+      end
+
+      it "splits the payload into smaller chunks" do
+        expect(client).to receive(:save_inventory_with_http_info).exactly(10).times
+        is_expected.to eq 10
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-949

This will allow us to configure the `max_bytes` size for kafka messages based on an ENV var, without the ENV var set the old behavior will continue. 
