### PR TITLE
Add specs to released files

### DIFF
--- a/topological_inventory-providers-common.gemspec
+++ b/topological_inventory-providers-common.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0")
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
repos with availability_check operation uses `RSpec.shared_examples` from gem. 
This PR allows spec files to be released to rubygems