### PR TITLE
Allow logger severity

### DIFF
--- a/lib/topological_inventory/providers/common/logging.rb
+++ b/lib/topological_inventory/providers/common/logging.rb
@@ -36,17 +36,17 @@ module TopologicalInventory
           else
             case severity.to_s.downcase
             when 'debug'
-              @level = DEBUG
+              @level = self.class::DEBUG
             when 'info'
-              @level = INFO
+              @level = self.class::INFO
             when 'warn'
-              @level = WARN
+              @level = self.class::WARN
             when 'error'
-              @level = ERROR
+              @level = self.class::ERROR
             when 'fatal'
-              @level = FATAL
+              @level = self.class::FATAL
             when 'unknown'
-              @level = UNKNOWN
+              @level = self.class::UNKNOWN
             else
               raise ArgumentError, "invalid log level: #{severity}"
             end

--- a/lib/topological_inventory/providers/common/logging.rb
+++ b/lib/topological_inventory/providers/common/logging.rb
@@ -29,6 +29,29 @@ module TopologicalInventory
         def log_with_prefix(prefix, message, severity)
           send(severity, "#{prefix} - #{message}") if respond_to?(severity)
         end
+
+        def level=(severity)
+          if severity.is_a?(Integer)
+            @level = severity
+          else
+            case severity.to_s.downcase
+            when 'debug'
+              @level = DEBUG
+            when 'info'
+              @level = INFO
+            when 'warn'
+              @level = WARN
+            when 'error'
+              @level = ERROR
+            when 'fatal'
+              @level = FATAL
+            when 'unknown'
+              @level = UNKNOWN
+            else
+              raise ArgumentError, "invalid log level: #{severity}"
+            end
+          end
+        end
       end
 
       class Logger < ManageIQ::Loggers::CloudWatch


### PR DESCRIPTION
skipping the `manageiq-loggers` overwritten method `logger=`. 
I get the point that DEBUG will be default for containers, but don't understand why it can't be changed at least temporary by any inherited logger. 
Changing it only for us will be faster at this moment. 
