### PR TITLE
Add some error handling if Sources does not have endpoints/authentications for a source

### DIFF
--- a/lib/topological_inventory/providers/common/operations/source.rb
+++ b/lib/topological_inventory/providers/common/operations/source.rb
@@ -116,10 +116,16 @@ module TopologicalInventory
 
         def endpoint
           @endpoint ||= api_client.fetch_default_endpoint(source_id)
+        rescue StandardError => e
+          logger.availability_check("Failed to fetch Endpoint for Source #{source_id}, Endpoint #{endpoint}: #{e.message}", :error)
+          return
         end
 
         def authentication
           @authentication ||= api_client.fetch_authentication(source_id, endpoint)
+        rescue StandardError => e
+          logger.availability_check("Failed to fetch Authentication for Source #{source_id}, Endpoint #{endpoint}: #{e.message}", :error)
+          return
         end
 
         def check_time


### PR DESCRIPTION
It's looking like some of the operations workers are crashing due to the fact that sources is throwing a 404 on `fetch_default_endpoint`. This error handling should make that particular source fail instead of crashing the entire worker. 
