### PR TITLE
Add check for Application subresource under a Source during Availability check

### DIFF
--- a/lib/topological_inventory/providers/common/operations/source.rb
+++ b/lib/topological_inventory/providers/common/operations/source.rb
@@ -12,8 +12,8 @@ module TopologicalInventory
         STATUS_AVAILABLE, STATUS_UNAVAILABLE = %w[available unavailable].freeze
 
         ERROR_MESSAGES = {
-          :authentication_not_found => "Authentication not found in Sources API",
-          :endpoint_not_found       => "Endpoint not found in Sources API",
+          :authentication_not_found          => "Authentication not found in Sources API",
+          :endpoint_or_application_not_found => "Endpoint or Application not found in Sources API",
         }.freeze
 
         LAST_CHECKED_AT_THRESHOLD = 5.minutes.freeze
@@ -33,7 +33,7 @@ module TopologicalInventory
 
           status, error_message = connection_status
 
-          update_source_and_endpoint(status, error_message)
+          update_source_and_subresources(status, error_message)
 
           logger.availability_check("Completed: Source #{source_id} is #{status}")
         end
@@ -57,20 +57,43 @@ module TopologicalInventory
         end
 
         def checked_recently?
-          return false if endpoint.nil?
+          checked_recently = if endpoint.present?
+                               endpoint.last_checked_at.present? && endpoint.last_checked_at >= LAST_CHECKED_AT_THRESHOLD.ago
+                             elsif application.present?
+                               application.last_checked_at.present? && application.last_checked_at >= LAST_CHECKED_AT_THRESHOLD.ago
+                             end
 
-          checked_recently = endpoint.last_checked_at.present? && endpoint.last_checked_at >= LAST_CHECKED_AT_THRESHOLD.ago
-          logger.availability_check("Skipping, last check at #{endpoint.last_checked_at} [Source ID: #{source_id}] ") if checked_recently
+          logger.availability_check("Skipping, last check at #{endpoint.last_checked_at || application.last_checked_at} [Source ID: #{source_id}] ") if checked_recently
 
           checked_recently
         end
 
         def connection_status
-          return [STATUS_UNAVAILABLE, ERROR_MESSAGES[:endpoint_not_found]] unless endpoint
-          return [STATUS_UNAVAILABLE, ERROR_MESSAGES[:authentication_not_found]] unless authentication
+          # we need either an endpoint or application to check the source.
+          return [STATUS_UNAVAILABLE, ERROR_MESSAGES[:endpoint_or_application_not_found]] unless endpoint || application
 
           check_time
+          if endpoint
+            endpoint_connection_check
+          elsif application
+            application_connection_check
+          end
+        end
+
+        def endpoint_connection_check
+          return [STATUS_UNAVAILABLE, ERROR_MESSAGES[:authentication_not_found]] unless authentication
+
+          # call down into the operations pod implementation of `Source#connection_check`
           connection_check
+        end
+
+        def application_connection_check
+          case application.availability_status
+          when "available"
+            [STATUS_AVAILABLE, nil]
+          when "unavailable"
+            [STATUS_UNAVAILABLE, "Application id #{application.id} unavailable"]
+          end
         end
 
         # @return [Array<String, String|nil] - STATUS_[UN]AVAILABLE, error message
@@ -78,11 +101,13 @@ module TopologicalInventory
           raise NotImplementedError, "#{__method__} must be implemented in a subclass"
         end
 
-        def update_source_and_endpoint(status, error_message = nil)
+        def update_source_and_subresources(status, error_message = nil)
           logger.availability_check("Updating source [#{source_id}] status [#{status}] message [#{error_message}]")
 
           update_source(status)
-          update_endpoint(status, error_message)
+
+          update_endpoint(status, error_message) if endpoint
+          update_application(status) if application
         end
 
         def update_source(status)
@@ -114,6 +139,16 @@ module TopologicalInventory
           logger.availability_check("Failed to update Endpoint(ID: #{endpoint.id}) - #{e.message}", :error)
         end
 
+        def update_application(status)
+          application_update = ::SourcesApiClient::Application.new
+          application_update.last_checked_at     = check_time
+          application_update.last_available_at   = check_time if status == STATUS_AVAILABLE
+
+          api_client.update_application(application.id, application_update)
+        rescue ::SourcesApiClient::ApiError => e
+          logger.availability_check("Failed to update Application id: #{application.id} - #{e.message}", :error)
+        end
+
         def endpoint
           @endpoint ||= api_client.fetch_default_endpoint(source_id)
         rescue StandardError => e
@@ -126,6 +161,12 @@ module TopologicalInventory
         rescue StandardError => e
           logger.availability_check("Failed to fetch Authentication for Source #{source_id}, Endpoint #{endpoint}: #{e.message}", :error)
           return
+        end
+
+        def application
+          @application ||= api_client.fetch_application(source_id)
+        rescue e
+          logger.availability_check("Failed to fetch Application for Source #{source_id}: #{e.message}", :error)
         end
 
         def check_time

--- a/lib/topological_inventory/providers/common/operations/sources_api_client.rb
+++ b/lib/topological_inventory/providers/common/operations/sources_api_client.rb
@@ -5,7 +5,7 @@ module TopologicalInventory
     module Common
       module Operations
         class SourcesApiClient < ::SourcesApiClient::ApiClient
-          delegate :update_source, :update_endpoint, :to => :api
+          delegate :update_source, :update_endpoint, :update_application, :to => :api
 
           INTERNAL_API_PATH = '//internal/v1.0'.freeze
 
@@ -23,6 +23,11 @@ module TopologicalInventory
           def fetch_default_endpoint(source_id)
             endpoints = api.list_source_endpoints(source_id)&.data || []
             endpoints.find(&:default)
+          end
+
+          def fetch_application(source_id)
+            applications = api.list_source_applications(source_id)&.data || []
+            applications.first
           end
 
           def fetch_authentication(source_id, default_endpoint = nil, authtype = nil)


### PR DESCRIPTION
Should solve https://projects.engineering.redhat.com/browse/TPINVTRY-988

After discussions about whether an Endpoint is necessary on a Source or not we came ot the conclusion that we should really treat the Source that an Application lives under as a different "type" of source, i.e. some sources have endpoints, others have applications. This will check if there is an application present if there is no endpoint. 

\# TODO:
- [x] specs
