### PR TITLE
Added refresh-type to save and sweep inventory

### DIFF
--- a/lib/topological_inventory/providers/common/collector.rb
+++ b/lib/topological_inventory/providers/common/collector.rb
@@ -104,7 +104,8 @@ module TopologicalInventory
                            refresh_state_uuid = nil,
                            refresh_state_part_uuid = nil,
                            refresh_state_part_collected_at = nil,
-                           refresh_state_part_sent_at = Time.now.utc)
+                           refresh_state_part_sent_at = Time.now.utc,
+                           refresh_type = default_refresh_type)
           return 0 if collections.empty?
 
           SaveInventory::Saver.new(:client => ingress_api_client, :logger => logger).save(
@@ -116,7 +117,8 @@ module TopologicalInventory
               :refresh_state_uuid              => refresh_state_uuid,
               :refresh_state_part_uuid         => refresh_state_part_uuid,
               :refresh_state_part_collected_at => refresh_state_part_collected_at,
-              :refresh_state_part_sent_at      => refresh_state_part_sent_at
+              :refresh_state_part_sent_at      => refresh_state_part_sent_at,
+              :refresh_type                    => refresh_type
             )
           )
         rescue => e
@@ -134,7 +136,8 @@ module TopologicalInventory
                             total_parts,
                             sweep_scope,
                             refresh_state_started_at = nil,
-                            refresh_state_sent_at = Time.now.utc)
+                            refresh_state_sent_at = Time.now.utc,
+                            refresh_type = default_refresh_type)
           return if !total_parts || sweep_scope.empty?
 
           SaveInventory::Saver.new(:client => ingress_api_client, :logger => logger).save(
@@ -147,7 +150,8 @@ module TopologicalInventory
               :total_parts              => total_parts,
               :sweep_scope              => sweep_scope,
               :refresh_state_started_at => refresh_state_started_at,
-              :refresh_state_sent_at    => refresh_state_sent_at
+              :refresh_state_sent_at    => refresh_state_sent_at,
+              :refresh_type             => refresh_type
             )
           )
         rescue => e
@@ -163,6 +167,10 @@ module TopologicalInventory
 
         def schema_name
           "Default"
+        end
+
+        def default_refresh_type
+          'full-refresh'
         end
 
         def ingress_api_client

--- a/topological_inventory-providers-common.gemspec
+++ b/topological_inventory-providers-common.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "manageiq-loggers", ">= 0.4.2"
   spec.add_runtime_dependency "sources-api-client", "~> 3.0"
   spec.add_runtime_dependency "topological_inventory-api-client", "~> 3.0", ">= 3.0.1"
-  spec.add_runtime_dependency "topological_inventory-ingress_api-client", "~> 1.0"
+  spec.add_runtime_dependency "topological_inventory-ingress_api-client", "~> 1.0", ">= 1.0.3"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-persister/issues/66

Adding refresh_type: string to Inventory to help recognizing the type of payload in persister. 

Defaults to "full-refresh"

---

**Depends on**
- [x] https://github.com/RedHatInsights/topological_inventory-ingress_api-client-ruby/pull/68
- [x] https://github.com/RedHatInsights/topological_inventory-ingress_api-client-ruby/pull/69
