### PR TITLE
Add HealthCheck class for operations workers

### DIFF
--- a/lib/topological_inventory/providers/common.rb
+++ b/lib/topological_inventory/providers/common.rb
@@ -2,6 +2,7 @@ require "topological_inventory/providers/common/version"
 require "topological_inventory/providers/common/logging"
 require "topological_inventory/providers/common/operations/processor"
 require "topological_inventory/providers/common/operations/endpoint_client"
+require "topological_inventory/providers/common/operations/health_check"
 require "topological_inventory/providers/common/collectors_pool"
 require "topological_inventory/providers/common/collector"
 

--- a/lib/topological_inventory/providers/common/operations/health_check.rb
+++ b/lib/topological_inventory/providers/common/operations/health_check.rb
@@ -1,0 +1,15 @@
+module TopologicalInventory
+  module Providers
+    module Common
+      module Operations
+        class HealthCheck
+          HEARTBEAT_FILE = '/tmp/healthy'.freeze
+
+          def self.touch_file
+            FileUtils.touch(HEARTBEAT_FILE)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Just adding a simple shared class for HealthChecks, the premise is that we call:
`TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file` 

after each successful message process operation. 

From there OCP will know if the operations worker is processing messages (since it should process at minimum a message per hour)