### PR TITLE
Set the LOG_LEVEL if present

### DIFF
--- a/lib/topological_inventory/providers/common/logging.rb
+++ b/lib/topological_inventory/providers/common/logging.rb
@@ -33,7 +33,10 @@ module TopologicalInventory
 
       class Logger < ManageIQ::Loggers::CloudWatch
         def self.new(*args)
-          super.tap { |logger| logger.extend(TopologicalInventory::Providers::Common::LoggingFunctions) }
+          super.tap do |logger|
+            logger.extend(TopologicalInventory::Providers::Common::LoggingFunctions)
+            logger.level = ENV['LOG_LEVEL'] if ENV['LOG_LEVEL']
+          end
         end
       end
 


### PR DESCRIPTION
The ContainerLogger will still output everything (since it is debug), but this way the CloudWatch logger can be independently tuned.

Thanks to @Fryguy for helping me figure this one out, I missed this line: 
https://github.com/ManageIQ/manageiq-loggers/blob/master/lib/manageiq/loggers/cloud_watch.rb#L16 

which shows it returning the container logger (which just logs debug because we always want the log level to be debug in the container), but when I set the appropriate ENV vars I can adjust the log level for the CloudWatch logger. 

This should allow us to lower our CW log output by setting LOG_LEVEL in each application deployment.

e2e-deploy PR here: https://github.com/RedHatInsights/e2e-deploy/pull/2150

cc @gmcculloug @syncrou 