### PR TITLE
Add availability checks for sources by kafka

### DIFF
--- a/lib/topological_inventory/providers/common/messaging_client.rb
+++ b/lib/topological_inventory/providers/common/messaging_client.rb
@@ -1,0 +1,40 @@
+require "more_core_extensions/core_ext/module/cache_with_timeout"
+require "manageiq-messaging"
+
+module TopologicalInventory
+  module Providers
+    module Common
+      class MessagingClient
+        # Kafka host name
+        attr_accessor :queue_host
+        # Kafka port
+        attr_accessor :queue_port
+
+        def initialize
+          @queue_host = ENV['QUEUE_HOST'] || 'localhost'
+          @queue_port = (ENV['QUEUE_PORT'] || 9092).to_i
+        end
+
+        def self.default
+          @@default ||= new
+        end
+
+        def self.configure
+          if block_given?
+            yield(default)
+          else
+            default
+          end
+        end
+
+        cache_with_timeout(:client) do
+          ManageIQ::Messaging::Client.open(:protocol => :Kafka, :host => @queue_host, :port => @queue_port)
+        end
+
+        def client
+          self.class.client
+        end
+      end
+    end
+  end
+end

--- a/topological_inventory-providers-common.gemspec
+++ b/topological_inventory-providers-common.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'config', '~> 1.7', '>= 1.7.2'
   spec.add_runtime_dependency 'json', '~> 2.3'
   spec.add_runtime_dependency "manageiq-loggers", ">= 0.4.2"
+  spec.add_runtime_dependency "manageiq-messaging", "~> 1.0.0"
+  spec.add_runtime_dependency "more_core_extensions"
   spec.add_runtime_dependency "prometheus_exporter", "~> 0.4.17"
   spec.add_runtime_dependency "sources-api-client", "~> 3.0"
   spec.add_runtime_dependency "topological_inventory-api-client", "~> 3.0", ">= 3.0.1"


### PR DESCRIPTION
Description:
---
Add a new Kafka based #availability_checks methods.

This PR is base on the https://issues.redhat.com/browse/RHCLOUD-9328

related PRs:
 * https://github.com/RedHatInsights/e2e-deploy/pull/2414
 * https://github.com/RedHatInsights/topological_inventory-ansible_tower/pull/139

Testing:
---
1) cd .../scripts
2) starth.sh
3) services/ansible-tower-operations.sh
4) api/dev.sh
  - I modfied the code to just call the availability_check for my existing source with ID equal to 4.

```
#!/usr/bin/env bash

source "api/common.sh"

sources_api_post "sources/4/check_availability"
echo ""
```
### ansible-tower-operations
![Screenshot from 2020-10-01 13-43-10](https://user-images.githubusercontent.com/19405716/94805084-18501a00-03ec-11eb-8811-8154f6d1783e.png)


### Kafka messages received
![Screenshot from 2020-10-01 13-44-57](https://user-images.githubusercontent.com/19405716/94805227-53524d80-03ec-11eb-824d-0211c63fa4f7.png)

