### PR TITLE
Add Operations Async Worker class

### DIFF
--- a/lib/topological_inventory/providers/common/operations/async_worker.rb
+++ b/lib/topological_inventory/providers/common/operations/async_worker.rb
@@ -1,0 +1,56 @@
+require "topological_inventory/providers/common/logging"
+require "topological_inventory/providers/common/operations/health_check"
+
+module TopologicalInventory
+  module Providers
+    module Common
+      module Operations
+        class AsyncWorker
+          include Logging
+
+          def initialize(processor, queue = nil)
+            @processor = processor
+            @queue = queue || Queue.new
+          end
+
+          def start
+            return if thread.present?
+
+            @thread = Thread.new { listen }
+          end
+
+          def stop
+            thread&.exit
+          end
+
+          def enqueue(msg)
+            queue << msg
+          end
+
+          def listen
+            loop do
+              # the queue thread waits for a message to come during `Queue#pop`
+              msg = queue.pop
+              process_message(msg)
+            end
+          end
+
+          private
+
+          attr_reader :thread, :queue, :processor
+
+          def process_message(msg)
+            processor.process!(msg)
+          rescue => err
+            model, method = msg.message.to_s.split(".")
+            logger.error("#{model}##{method}: async worker failure: #{err.cause}\n#{err}\n#{err.backtrace.join("\n")}")
+          ensure
+            msg.ack
+            TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file
+            logger.debug("Operations::AsyncWorker queue length: #{queue.length}") if queue.length >= 20 && queue.length % 5 == 0
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/providers/common/operations/async_worker_spec.rb
+++ b/spec/topological_inventory/providers/common/operations/async_worker_spec.rb
@@ -1,0 +1,36 @@
+require "topological_inventory/providers/common/operations/async_worker"
+
+describe TopologicalInventory::Providers::Common::Operations::AsyncWorker do
+  let(:queue) { double }
+  let(:impl) { double }
+  let(:msg) { double }
+  subject { described_class.new(impl, queue) }
+
+  before do
+    allow(queue).to receive(:length).and_return(0)
+    allow(msg).to receive(:message).and_return("Source.availability_check")
+  end
+
+  context "when the message is able to be processed" do
+    before do
+      allow(impl).to receive(:process!).with(msg)
+      allow(msg).to receive(:ack)
+    end
+
+    it "drains messages that are added to the queue" do
+      expect(impl).to receive(:process!).with(msg).once
+      subject.send(:process_message, msg)
+    end
+  end
+
+  context "when the message results in an error" do
+    before do
+      allow(impl).to receive(:process!).with(msg).and_raise(StandardError.new("boom!"))
+    end
+
+    it "ack's the message on failure" do
+      expect(msg).to receive(:ack).once
+      subject.send(:process_message, msg)
+    end
+  end
+end


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-9652

Common changes for this, basically adding the `AsyncWorker` class which takes the shared queue and the `Processor` class as arguments, from there the main worker can just throw things on the queue that we don't quite care about and it'll process them whenever it gets time. 

cc @slemrmartin @syncrou 