### PR TITLE
Rubocop rules from insights-api-common + yamllint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,31 @@
+---
+version: '2'
+prepare:
+  fetch:
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
+    path: ".rubocop_base.yml"
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_cc_base.yml
+    path: ".rubocop_cc_base.yml"
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-complexity:
+    config:
+      threshold: 11
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  return-statements:
+    enabled: false
+plugins:
+  rubocop:
+    enabled: true
+    config: ".rubocop_cc.yml"
+    channel: rubocop-1-0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
 - .rubocop_local.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+ignore: |
+
+extends: relaxed
+
+rules:
+  line-length:
+    max: 120

--- a/topological_inventory-providers-common.gemspec
+++ b/topological_inventory-providers-common.gemspec
@@ -26,19 +26,20 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', '~> 5.2.4.3'
   spec.add_runtime_dependency 'config', '~> 1.7', '>= 1.7.2'
   spec.add_runtime_dependency 'json', '~> 2.3'
-  spec.add_runtime_dependency "manageiq-loggers", ">= 0.4.2"
-  spec.add_runtime_dependency "manageiq-messaging", "~> 1.0.0"
-  spec.add_runtime_dependency "more_core_extensions"
-  spec.add_runtime_dependency "prometheus_exporter", "~> 0.4.17"
-  spec.add_runtime_dependency "sources-api-client", "~> 3.0"
-  spec.add_runtime_dependency "topological_inventory-api-client", "~> 3.0", ">= 3.0.1"
-  spec.add_runtime_dependency "topological_inventory-ingress_api-client", "~> 1.0", ">= 1.0.3"
+  spec.add_runtime_dependency 'manageiq-loggers', '>= 0.4.2'
+  spec.add_runtime_dependency 'manageiq-messaging', '~> 1.0.0'
+  spec.add_runtime_dependency 'more_core_extensions'
+  spec.add_runtime_dependency 'prometheus_exporter', '~> 0.4.17'
+  spec.add_runtime_dependency 'sources-api-client', '~> 3.0'
+  spec.add_runtime_dependency 'topological_inventory-api-client', '~> 3.0', '>= 3.0.1'
+  spec.add_runtime_dependency 'topological_inventory-ingress_api-client', '~> 1.0', '>= 1.0.3'
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency 'rubocop', '~>0.69.0'
-  spec.add_development_dependency 'rubocop-performance', '~>1.3'
-  spec.add_development_dependency "simplecov", "~> 0.17.1"
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop', '~> 1.0.0'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.8'
+  spec.add_development_dependency 'rubocop-rails', '~> 2.8'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
Because of https://github.com/ManageIQ/guides/pull/443 rubocop rules were moved to another repo. 
So we are moving the file to our common repo.

* [x] depends on https://github.com/RedHatInsights/insights-api-common-rails/pull/211

---

[RHCLOUD-10237](https://issues.redhat.com/browse/RHCLOUD-10237)
