### PR TITLE
Custom Metrics for AsyncWorker

### DIFF
--- a/lib/topological_inventory/providers/common/operations/source.rb
+++ b/lib/topological_inventory/providers/common/operations/source.rb
@@ -30,7 +30,7 @@ module TopologicalInventory
           attr_accessor :identity, :operation, :params, :request_context, :source_id, :account_number
 
           def initialize(params = {}, request_context = nil, metrics = nil)
-            self.metrics         = metrics
+            self.metrics           = metrics
             self.operation         = 'Source'
             self.params            = params
             self.request_context   = request_context

--- a/spec/topological_inventory/providers/common/operations/async_worker_spec.rb
+++ b/spec/topological_inventory/providers/common/operations/async_worker_spec.rb
@@ -3,33 +3,42 @@ require "topological_inventory/providers/common/operations/async_worker"
 describe TopologicalInventory::Providers::Common::Operations::AsyncWorker do
   let(:queue) { double }
   let(:impl) { double }
+  let(:metrics) { double('metrics') }
   let(:msg) { double }
-  subject { described_class.new(impl, queue) }
+  let(:operation) { "Source.availability_check" }
+
+  subject { described_class.new(impl, :queue => queue, :metrics => metrics) }
 
   before do
     allow(queue).to receive(:length).and_return(0)
-    allow(msg).to receive(:message).and_return("Source.availability_check")
+    allow(msg).to receive(:message).and_return(operation)
   end
 
   context "when the message is able to be processed" do
+    let(:result) { subject.operation_status[:success] }
     before do
-      allow(impl).to receive(:process!).with(msg)
+      allow(impl).to receive(:process!).with(msg, metrics).and_return(result)
       allow(msg).to receive(:ack)
     end
 
     it "drains messages that are added to the queue" do
-      expect(impl).to receive(:process!).with(msg).once
+      expect(impl).to receive(:process!).with(msg, metrics).once
+      expect(metrics).to receive(:record_operation).with(operation, :status => result)
       subject.send(:process_message, msg)
     end
   end
 
   context "when the message results in an error" do
+    let(:result) { subject.operation_status[:error] }
     before do
-      allow(impl).to receive(:process!).with(msg).and_raise(StandardError.new("boom!"))
+      allow(impl).to receive(:process!).with(msg, metrics).and_raise(StandardError.new("boom!"))
     end
 
     it "ack's the message on failure" do
+      allow(subject).to receive(:logger).and_return(double.as_null_object)
+      
       expect(msg).to receive(:ack).once
+      expect(metrics).to receive(:record_operation).with(operation, :status => result)
       subject.send(:process_message, msg)
     end
   end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320

- Metrics collecting in Operations AsyncWorker

Applying the same rules like Operation Workers have (currently used in AnsibleTower repo)

---

[RHCLOUD-9949](https://issues.redhat.com/browse/RHCLOUD-9949)
