### PR TITLE
Change error metric name to errors_total

### DIFF
--- a/lib/topological_inventory/providers/common/metrics.rb
+++ b/lib/topological_inventory/providers/common/metrics.rb
@@ -67,7 +67,7 @@ module TopologicalInventory
           PrometheusExporter::Metric::Base.default_prefix = default_prefix
 
           @duration_seconds = PrometheusExporter::Metric::Histogram.new('duration_seconds', 'Duration of processed operation')
-          @error_counter = PrometheusExporter::Metric::Counter.new("error", ERROR_COUNTER_MESSAGE)
+          @error_counter = PrometheusExporter::Metric::Counter.new('errors_total', ERROR_COUNTER_MESSAGE)
           @status_counter = PrometheusExporter::Metric::Counter.new('status_counter', 'number of processed operations')
 
           [@duration_seconds, @error_counter, @status_counter].each do |metric|


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320

Metric with suffix `_error` is not available in list of metrics in prometheus, I'll try to change the name

---

[RHCLOUD-9949](https://issues.redhat.com/browse/RHCLOUD-9949)