### PR TITLE
Include x-rh-id header in Kafka Availability-Status message

### DIFF
--- a/lib/topological_inventory/providers/common/operations/source.rb
+++ b/lib/topological_inventory/providers/common/operations/source.rb
@@ -211,7 +211,8 @@ module TopologicalInventory
             messaging_client.publish_topic(
               :service => SERVICE_NAME,
               :event   => EVENT_AVAILABILITY_STATUS,
-              :payload => payload.to_json
+              :payload => payload.to_json,
+              :headers => identity
             )
           rescue => err
             logger.availability_check("Failed to update #{payload[:resource_type]} id: #{payload[:resource_id]} - #{err.message}", :error)

--- a/spec/support/shared/availability_check.rb
+++ b/spec/support/shared/availability_check.rb
@@ -44,6 +44,9 @@ RSpec.shared_examples "availability_check" do
         :resource_type => resource_type,
         :resource_id   => resource_id,
         :status        => status
+      },
+      :headers => {
+        "x-rh-identity" => "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjExMDAxIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9fX0="
       }
     }
     res[:payload][:error] = error_message if error_message


### PR DESCRIPTION
So when passing availability-status messages we need to include the `x-rh-identity` header much like the api clients would.

This is for cost management currently, but others may use this in the future on the event-stream to communicate back with us. 